### PR TITLE
Expose all particle metrics in Influx and dashboard

### DIFF
--- a/dashboard/public/app.js
+++ b/dashboard/public/app.js
@@ -13,10 +13,17 @@ function buildSeries(rows, selected) {
     co2: '#e74c3c',
     temperature: '#f39c12',
     humidity: '#3498db',
+    pm1_0: '#1abc9c',
     pm2_5: '#9b59b6',
+    pm4_0: '#2c3e50',
     pm10: '#8e44ad',
     voc: '#2ecc71',
-    nox: '#16a085'
+    nox: '#16a085',
+    nc0_5: '#d35400',
+    nc1_0: '#c0392b',
+    nc2_5: '#7f8c8d',
+    nc4_0: '#95a5a6',
+    nc10: '#34495e'
   };
   return selected.map(f => ({ name: f, data: byField.get(f) || [], color: palette[f] }));
 }

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -41,8 +41,15 @@
         <label><input type="checkbox" class="field" value="co2" checked /> CO2 (ppm)</label>
         <label><input type="checkbox" class="field" value="temperature" checked /> Temperatur (°C)</label>
         <label><input type="checkbox" class="field" value="humidity" checked /> Luftfeuchte (%)</label>
+        <label><input type="checkbox" class="field" value="pm1_0" /> PM1.0 (µg/m³)</label>
         <label><input type="checkbox" class="field" value="pm2_5" /> PM2.5 (µg/m³)</label>
+        <label><input type="checkbox" class="field" value="pm4_0" /> PM4.0 (µg/m³)</label>
         <label><input type="checkbox" class="field" value="pm10" /> PM10 (µg/m³)</label>
+        <label><input type="checkbox" class="field" value="nc0_5" /> NC0.5 (#/cm³)</label>
+        <label><input type="checkbox" class="field" value="nc1_0" /> NC1.0 (#/cm³)</label>
+        <label><input type="checkbox" class="field" value="nc2_5" /> NC2.5 (#/cm³)</label>
+        <label><input type="checkbox" class="field" value="nc4_0" /> NC4.0 (#/cm³)</label>
+        <label><input type="checkbox" class="field" value="nc10" /> NC10 (#/cm³)</label>
         <label><input type="checkbox" class="field" value="voc" /> VOC (Index)</label>
         <label><input type="checkbox" class="field" value="nox" /> NOx (Index)</label>
       </div>

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -97,7 +97,7 @@ app.get('/api/history', async (req, res) => {
   try {
     const range = (req.query.range && String(req.query.range)) || '-24h';
     // Comma-separated list of fields; default to a useful set
-    const defaultFields = ['co2','temperature','humidity','pm2_5','pm10','voc','nox'];
+    const defaultFields = ['co2','temperature','humidity','pm1_0','pm2_5','pm4_0','pm10','voc','nox','nc0_5','nc1_0','nc2_5','nc4_0','nc10'];
     const fields = (req.query.fields ? String(req.query.fields).split(',') : defaultFields).map(f => f.trim()).filter(Boolean);
     // Optional downsampling window, e.g. 1m, 5m, 10m. Empty means no aggregation
     const every = req.query.every ? String(req.query.every) : '';

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,6 +74,11 @@ static void sendToInflux(const Sen66::MeasuredValues &mv, const Sen66::NumberCon
                 ",voc=" + f2s(mv.voc_index, 1) +
                 ",nox=" + f2s(mv.nox_index, 1) +
                 ",co2=" + f2s(mv.co2_ppm, 0) +
+                ",nc0_5=" + f2s(nc.nc0_5, 1) +
+                ",nc1_0=" + f2s(nc.nc1_0, 1) +
+                ",nc2_5=" + f2s(nc.nc2_5, 1) +
+                ",nc4_0=" + f2s(nc.nc4_0, 1) +
+                ",nc10="  + f2s(nc.nc10_0, 1) +
                 ",status=" + String((unsigned long)statusFlags);
   http.begin(url);
   http.addHeader("Authorization", String("Token ") + INFLUXDB_TOKEN);


### PR DESCRIPTION
## Summary
- upload number concentration values to InfluxDB
- allow selecting PM1.0/PM4.0 and number concentration series in dashboard

## Testing
- `npm test`
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_68b0a44c39608332b510b112fa7ff2d4